### PR TITLE
feat: hexagonal grid with explore-to-place mechanic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,6 @@ function GameScreen() {
     phase,
     lastCombat,
     winner,
-    endTurn,
     dismissCombat,
     resetGame,
   } = useGameStore();
@@ -46,23 +45,11 @@ function GameScreen() {
                 style={{ backgroundColor: currentPlayer?.cup.color }}
               />
               <span className="font-bold">{currentPlayer?.name}'s turn</span>
-              <span className="text-gray-400 ml-2">— Click an adjacent tile to move</span>
+              <span className="text-gray-400 ml-2">— Hover over a hex to preview, click to explore</span>
             </p>
           </div>
 
           <Board />
-
-          <div className="mt-4 flex gap-2">
-            <button
-              onClick={endTurn}
-              disabled={phase !== 'playing'}
-              className="flex-1 py-2 bg-dungeon-light hover:bg-dungeon-medium
-                         text-white font-semibold rounded-lg transition-colors
-                         disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              End Turn
-            </button>
-          </div>
         </div>
 
         {/* Sidebar */}

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,96 +1,223 @@
-import { useGameStore } from '../game/store';
-import { Tile, Player } from '../game/types';
+import { useState, useMemo } from 'react';
+import { useGameStore, getPlaceablePositions } from '../game/store';
+import { Tile, Player, HexCoord } from '../game/types';
 
-interface TileProps {
-  tile: Tile;
-  playersOnTile: Player[];
-  isAdjacent: boolean;
-  onClick: () => void;
+const HEX_SIZE = 50; // Radius of hexagon
+const SQRT3 = Math.sqrt(3);
+
+// Convert axial coordinates to pixel position (flat-top hexagons)
+function hexToPixel(q: number, r: number): { x: number; y: number } {
+  const x = HEX_SIZE * (3 / 2) * q;
+  const y = HEX_SIZE * ((SQRT3 / 2) * q + SQRT3 * r);
+  return { x, y };
 }
 
-function TileCell({ tile, playersOnTile, isAdjacent, onClick }: TileProps) {
-  const getTileContent = () => {
-    if (!tile.revealed) {
-      return <span className="text-2xl">❓</span>;
-    }
-    if (tile.monster) {
-      return <span className="text-2xl">👹</span>;
-    }
-    if (tile.isStart) {
-      return <span className="text-2xl">🏠</span>;
-    }
-    return <span className="text-2xl opacity-50">·</span>;
+// SVG path for a flat-top hexagon
+function hexagonPath(size: number): string {
+  const points: string[] = [];
+  for (let i = 0; i < 6; i++) {
+    const angle = (Math.PI / 180) * (60 * i);
+    const px = size * Math.cos(angle);
+    const py = size * Math.sin(angle);
+    points.push(`${px},${py}`);
+  }
+  return `M ${points.join(' L ')} Z`;
+}
+
+interface HexTileProps {
+  tile: Tile;
+  playersOnTile: Player[];
+  pixelPos: { x: number; y: number };
+}
+
+function HexTile({ tile, playersOnTile, pixelPos }: HexTileProps) {
+  const getTileEmoji = () => {
+    if (tile.monster) return '👹';
+    if (tile.isStart) return '🏠';
+    return '·';
   };
 
   return (
-    <button
-      onClick={onClick}
-      disabled={!isAdjacent}
-      className={`
-        relative w-16 h-16 rounded-lg border-2 flex items-center justify-center
-        transition-all duration-200
-        ${tile.revealed
-          ? 'bg-dungeon-medium border-dungeon-light'
-          : 'bg-dungeon-dark border-gray-700'}
-        ${isAdjacent
-          ? 'border-dungeon-accent cursor-pointer hover:bg-dungeon-light hover:scale-105'
-          : 'cursor-default'}
-        ${tile.monster && tile.revealed ? 'border-red-500' : ''}
-      `}
-    >
-      {getTileContent()}
+    <g transform={`translate(${pixelPos.x}, ${pixelPos.y})`}>
+      <path
+        d={hexagonPath(HEX_SIZE - 2)}
+        className={`
+          fill-dungeon-medium stroke-dungeon-light stroke-2
+          ${tile.monster ? 'stroke-red-500' : ''}
+        `}
+      />
+      <text
+        className="fill-white text-2xl select-none"
+        textAnchor="middle"
+        dominantBaseline="central"
+        style={{ fontSize: '24px' }}
+      >
+        {getTileEmoji()}
+      </text>
 
       {/* Player tokens */}
       {playersOnTile.length > 0 && (
-        <div className="absolute -bottom-1 left-1/2 -translate-x-1/2 flex gap-0.5">
-          {playersOnTile.map(player => (
-            <div
-              key={player.id}
-              className="w-3 h-3 rounded-full border border-white"
-              style={{ backgroundColor: player.cup.color }}
-              title={player.name}
-            />
-          ))}
-        </div>
+        <g transform={`translate(0, ${HEX_SIZE * 0.5})`}>
+          {playersOnTile.map((player, i) => {
+            const offset = (i - (playersOnTile.length - 1) / 2) * 14;
+            return (
+              <circle
+                key={player.id}
+                cx={offset}
+                cy={0}
+                r={6}
+                fill={player.cup.color}
+                stroke="white"
+                strokeWidth={2}
+              />
+            );
+          })}
+        </g>
       )}
-    </button>
+    </g>
+  );
+}
+
+interface PlaceableHexProps {
+  coord: HexCoord;
+  pixelPos: { x: number; y: number };
+  isHovered: boolean;
+  onHover: (coord: HexCoord | null) => void;
+  onClick: () => void;
+}
+
+function PlaceableHex({ coord, pixelPos, isHovered, onHover, onClick }: PlaceableHexProps) {
+  return (
+    <g
+      transform={`translate(${pixelPos.x}, ${pixelPos.y})`}
+      onMouseEnter={() => onHover(coord)}
+      onMouseLeave={() => onHover(null)}
+      onClick={onClick}
+      className="cursor-pointer"
+    >
+      <path
+        d={hexagonPath(HEX_SIZE - 2)}
+        className={`
+          transition-all duration-200
+          ${isHovered
+            ? 'fill-dungeon-accent/40 stroke-dungeon-accent stroke-2'
+            : 'fill-transparent stroke-dungeon-accent/50 stroke-2 stroke-dashed'}
+        `}
+        style={{ strokeDasharray: isHovered ? 'none' : '8,4' }}
+      />
+      {isHovered && (
+        <text
+          className="fill-dungeon-accent text-xl select-none pointer-events-none"
+          textAnchor="middle"
+          dominantBaseline="central"
+          style={{ fontSize: '20px' }}
+        >
+          +
+        </text>
+      )}
+    </g>
   );
 }
 
 export function Board() {
-  const { map, players, currentPlayerIndex, phase, moveTo } = useGameStore();
-
-  if (map.length === 0) return null;
+  const { map, players, currentPlayerIndex, phase, placeTile } = useGameStore();
+  const [hoveredCoord, setHoveredCoord] = useState<HexCoord | null>(null);
 
   const currentPlayer = players[currentPlayerIndex];
-  const { x: px, y: py } = currentPlayer?.position ?? { x: 0, y: 0 };
 
-  const isAdjacent = (x: number, y: number) => {
-    if (phase !== 'playing') return false;
-    const dx = Math.abs(x - px);
-    const dy = Math.abs(y - py);
-    return dx + dy === 1;
+  // Get all placeable positions for current player
+  const placeablePositions = useMemo(() => {
+    if (phase !== 'playing' || !currentPlayer) return [];
+    return getPlaceablePositions(map, currentPlayer.position);
+  }, [map, currentPlayer, phase]);
+
+  // Calculate bounds to center the view
+  const bounds = useMemo(() => {
+    let minX = Infinity, maxX = -Infinity;
+    let minY = Infinity, maxY = -Infinity;
+
+    // Include existing tiles
+    map.forEach((_, key) => {
+      const [q, r] = key.split(',').map(Number);
+      const pos = hexToPixel(q, r);
+      minX = Math.min(minX, pos.x);
+      maxX = Math.max(maxX, pos.x);
+      minY = Math.min(minY, pos.y);
+      maxY = Math.max(maxY, pos.y);
+    });
+
+    // Include placeable positions
+    placeablePositions.forEach(({ q, r }) => {
+      const pos = hexToPixel(q, r);
+      minX = Math.min(minX, pos.x);
+      maxX = Math.max(maxX, pos.x);
+      minY = Math.min(minY, pos.y);
+      maxY = Math.max(maxY, pos.y);
+    });
+
+    const padding = HEX_SIZE * 1.5;
+    return {
+      x: minX - padding,
+      y: minY - padding,
+      width: maxX - minX + padding * 2,
+      height: maxY - minY + padding * 2,
+    };
+  }, [map, placeablePositions]);
+
+  if (map.size === 0) return null;
+
+  const getPlayersOnTile = (q: number, r: number) => {
+    return players.filter(
+      p => p.position.q === q && p.position.r === r && p.cup.currentLevel > 0
+    );
   };
 
-  const getPlayersOnTile = (x: number, y: number) => {
-    return players.filter(p => p.position.x === x && p.position.y === y && p.cup.currentLevel > 0);
-  };
+  // Convert map to array for rendering
+  const tiles = Array.from(map.entries()).map(([key, tile]) => ({
+    key,
+    tile,
+    pixelPos: hexToPixel(tile.q, tile.r),
+  }));
 
   return (
-    <div className="flex flex-col gap-1 p-4 bg-dungeon-dark/50 rounded-xl">
-      {map.map((row, y) => (
-        <div key={y} className="flex gap-1">
-          {row.map((tile, x) => (
-            <TileCell
-              key={`${x}-${y}`}
-              tile={tile}
-              playersOnTile={getPlayersOnTile(x, y)}
-              isAdjacent={isAdjacent(x, y)}
-              onClick={() => moveTo(x, y)}
+    <div className="flex flex-col items-center gap-4 p-4 bg-dungeon-dark/50 rounded-xl">
+      <svg
+        viewBox={`${bounds.x} ${bounds.y} ${bounds.width} ${bounds.height}`}
+        className="w-full max-w-2xl"
+        style={{ minHeight: '400px' }}
+      >
+        {/* Placeable hexes (render first so they're behind) */}
+        {placeablePositions.map(coord => {
+          const pixelPos = hexToPixel(coord.q, coord.r);
+          const isHovered = hoveredCoord?.q === coord.q && hoveredCoord?.r === coord.r;
+          return (
+            <PlaceableHex
+              key={`placeable-${coord.q}-${coord.r}`}
+              coord={coord}
+              pixelPos={pixelPos}
+              isHovered={isHovered}
+              onHover={setHoveredCoord}
+              onClick={() => placeTile(coord.q, coord.r)}
             />
-          ))}
-        </div>
-      ))}
+          );
+        })}
+
+        {/* Existing tiles */}
+        {tiles.map(({ key, tile, pixelPos }) => (
+          <HexTile
+            key={key}
+            tile={tile}
+            playersOnTile={getPlayersOnTile(tile.q, tile.r)}
+            pixelPos={pixelPos}
+          />
+        ))}
+      </svg>
+
+      {phase === 'playing' && currentPlayer && (
+        <p className="text-dungeon-accent text-sm">
+          {currentPlayer.name}'s turn - click a hex to explore
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -1,5 +1,32 @@
 import { Player } from '../game/types';
 
+// Cup/drink icon SVG component
+function CupIcon({ filled, color }: { filled: boolean; color: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="w-5 h-5"
+      fill={filled ? color : 'transparent'}
+      stroke={filled ? color : '#4a4a4a'}
+      strokeWidth={2}
+    >
+      {/* Cup body */}
+      <path d="M5 6h14l-1.5 12a2 2 0 01-2 2H8.5a2 2 0 01-2-2L5 6z" />
+      {/* Cup rim */}
+      <path d="M4 6h16" strokeLinecap="round" />
+      {/* Liquid surface (wavy line) */}
+      {filled && (
+        <path
+          d="M7 10c1 1 2 0 3 0s2 1 3 0 2-1 3 0"
+          fill="none"
+          stroke="rgba(255,255,255,0.5)"
+          strokeWidth={1.5}
+        />
+      )}
+    </svg>
+  );
+}
+
 interface PlayerCardProps {
   player: Player;
   isActive: boolean;
@@ -7,7 +34,6 @@ interface PlayerCardProps {
 
 export function PlayerCard({ player, isActive }: PlayerCardProps) {
   const { cup } = player;
-  const healthPercent = (cup.currentLevel / cup.capacity) * 100;
   const isDead = cup.currentLevel <= 0;
 
   return (
@@ -32,33 +58,20 @@ export function PlayerCard({ player, isActive }: PlayerCardProps) {
         </span>
       </div>
 
-      {/* Drink meter (cup visualization) */}
-      <div className="relative w-full h-20 bg-gray-800 rounded-lg overflow-hidden border-2 border-gray-600">
-        {/* Liquid */}
-        <div
-          className="absolute bottom-0 left-0 right-0 transition-all duration-500 ease-out"
-          style={{
-            height: `${healthPercent}%`,
-            backgroundColor: cup.color,
-            opacity: 0.8,
-          }}
-        />
-
-        {/* Cup markings */}
+      {/* Cup icons grid (10 cups = 2 rows of 5) */}
+      <div className="grid grid-cols-5 gap-1">
         {[...Array(cup.capacity)].map((_, i) => (
-          <div
+          <CupIcon
             key={i}
-            className="absolute left-0 right-0 border-t border-gray-500/30"
-            style={{ bottom: `${((i + 1) / cup.capacity) * 100}%` }}
+            filled={i < cup.currentLevel}
+            color={cup.color}
           />
         ))}
+      </div>
 
-        {/* Level text */}
-        <div className="absolute inset-0 flex items-center justify-center">
-          <span className="text-white font-bold text-lg drop-shadow-lg">
-            {cup.currentLevel}/{cup.capacity}
-          </span>
-        </div>
+      {/* Health text */}
+      <div className="mt-2 text-center text-xs text-gray-400">
+        {cup.currentLevel}/{cup.capacity} drinks left
       </div>
 
       {/* Active indicator */}

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { GameState, Player, Tile, Monster, CombatResult, Cup } from './types';
+import { GameState, Player, Tile, Monster, CombatResult, Cup, HexMap, hexKey, getHexNeighbors, HexCoord } from './types';
 
 // Monster templates
 const MONSTERS: Omit<Monster, 'damage'>[] = [
@@ -19,54 +19,37 @@ const createCup = (color: string, capacity: number): Cup => ({
   currentLevel: capacity,
 });
 
-const generateMap = (width: number, height: number): Tile[][] => {
-  const map: Tile[][] = [];
-  for (let y = 0; y < height; y++) {
-    const row: Tile[] = [];
-    for (let x = 0; x < width; x++) {
-      const isStart = x === 0 && y === Math.floor(height / 2);
-      let monster: Monster | null = null;
+// Generate a random tile (called when player explores)
+const generateTile = (q: number, r: number): Tile => {
+  let monster: Monster | null = null;
 
-      // 30% chance for monster, but not on start tile
-      if (!isStart && Math.random() < 0.3) {
-        const template = MONSTERS[Math.floor(Math.random() * MONSTERS.length)];
-        monster = {
-          ...template,
-          damage: Math.ceil(Math.random() * 2), // 1-2 damage
-        };
-      }
-
-      row.push({
-        x,
-        y,
-        monster,
-        revealed: isStart,
-        isStart,
-      });
-    }
-    map.push(row);
+  // 30% chance for monster
+  if (Math.random() < 0.3) {
+    const template = MONSTERS[Math.floor(Math.random() * MONSTERS.length)];
+    monster = {
+      ...template,
+      damage: Math.ceil(Math.random() * 2), // 1-2 damage
+    };
   }
-  return map;
+
+  return { q, r, monster };
 };
 
-const PLAYER_COLORS = ['#e94560', '#4ecdc4', '#ffe66d', '#95e1d3', '#f38181', '#aa96da'];
+const PLAYER_COLORS = ['#e94560', '#4ecdc4', '#ffe66d', '#95e1d3', '#f38181', '#aa96da', '#a8d8ea', '#fcbad3', '#aa96da', '#f8b500'];
 
 interface GameStore extends GameState {
   // Actions
   startGame: (playerNames: string[]) => void;
-  moveTo: (x: number, y: number) => void;
-  endTurn: () => void;
-  resetGame: () => void;
+  placeTile: (q: number, r: number) => void;
   dismissCombat: () => void;
+  resetGame: () => void;
 }
 
 const initialState: GameState = {
   players: [],
-  map: [],
+  map: new Map(),
   currentPlayerIndex: 0,
   phase: 'setup',
-  width: 5,
-  height: 5,
   lastCombat: null,
   winner: null,
 };
@@ -75,19 +58,22 @@ export const useGameStore = create<GameStore>((set, get) => ({
   ...initialState,
 
   startGame: (playerNames: string[]) => {
-    const { width, height } = get();
-    const startY = Math.floor(height / 2);
+    // Create starting tile at origin
+    const startTile: Tile = { q: 0, r: 0, monster: null, isStart: true };
+    const map: HexMap = new Map();
+    map.set(hexKey(0, 0), startTile);
 
+    // All players start at origin with 10 health
     const players: Player[] = playerNames.map((name, i) => ({
       id: `player-${i}`,
       name,
-      cup: createCup(PLAYER_COLORS[i % PLAYER_COLORS.length], 5),
-      position: { x: 0, y: startY },
+      cup: createCup(PLAYER_COLORS[i % PLAYER_COLORS.length], 10),
+      position: { q: 0, r: 0 },
     }));
 
     set({
       players,
-      map: generateMap(width, height),
+      map,
       currentPlayerIndex: 0,
       phase: 'playing',
       lastCombat: null,
@@ -95,104 +81,94 @@ export const useGameStore = create<GameStore>((set, get) => ({
     });
   },
 
-  moveTo: (x: number, y: number) => {
+  placeTile: (q: number, r: number) => {
     const { map, players, currentPlayerIndex, phase } = get();
     if (phase !== 'playing') return;
 
     const player = players[currentPlayerIndex];
-    const { x: px, y: py } = player.position;
+    const { q: pq, r: pr } = player.position;
 
-    // Can only move to adjacent tiles
-    const dx = Math.abs(x - px);
-    const dy = Math.abs(y - py);
-    if (dx + dy !== 1) return; // Must be exactly 1 step
+    // Check if this is a valid neighbor of current position
+    const neighbors = getHexNeighbors(pq, pr);
+    const isNeighbor = neighbors.some(n => n.q === q && n.r === r);
+    if (!isNeighbor) return;
 
-    // Bounds check
-    if (x < 0 || y < 0 || x >= map[0].length || y >= map.length) return;
+    // Check tile doesn't already exist
+    const key = hexKey(q, r);
+    if (map.has(key)) return;
 
-    const tile = map[y][x];
-    const newMap = map.map(row => row.map(t => ({ ...t })));
+    // Create the new tile
+    const newTile = generateTile(q, r);
+    const newMap = new Map(map);
+    newMap.set(key, newTile);
+
+    // Move player to new tile
     const newPlayers = players.map(p => ({ ...p, cup: { ...p.cup } }));
+    newPlayers[currentPlayerIndex].position = { q, r };
 
-    // Move player
-    newPlayers[currentPlayerIndex].position = { x, y };
+    // Check for combat
+    if (newTile.monster) {
+      const roll = rollD20();
+      const won = roll >= newTile.monster.difficulty;
 
-    // Reveal tile if not revealed
-    if (!tile.revealed) {
-      newMap[y][x].revealed = true;
+      const combat: CombatResult = {
+        roll,
+        needed: newTile.monster.difficulty,
+        won,
+        monster: newTile.monster,
+      };
 
-      // Combat!
-      if (tile.monster) {
-        const roll = rollD20();
-        const won = roll >= tile.monster.difficulty;
+      if (!won) {
+        // Take damage
+        combat.damage = newTile.monster.damage;
+        newPlayers[currentPlayerIndex].cup.currentLevel -= newTile.monster.damage;
 
-        const combat: CombatResult = {
-          roll,
-          needed: tile.monster.difficulty,
-          won,
-          monster: tile.monster,
-        };
+        // Check for elimination
+        if (newPlayers[currentPlayerIndex].cup.currentLevel <= 0) {
+          newPlayers[currentPlayerIndex].cup.currentLevel = 0;
 
-        if (!won) {
-          // Take damage
-          combat.damage = tile.monster.damage;
-          newPlayers[currentPlayerIndex].cup.currentLevel -= tile.monster.damage;
-
-          // Check for elimination
-          if (newPlayers[currentPlayerIndex].cup.currentLevel <= 0) {
-            newPlayers[currentPlayerIndex].cup.currentLevel = 0;
-
-            // Check if game over (only one player left)
-            const alivePlayers = newPlayers.filter(p => p.cup.currentLevel > 0);
-            if (alivePlayers.length === 1) {
-              set({
-                players: newPlayers,
-                map: newMap,
-                phase: 'gameOver',
-                lastCombat: combat,
-                winner: alivePlayers[0],
-              });
-              return;
-            }
+          // Check if game over (only one player left)
+          const alivePlayers = newPlayers.filter(p => p.cup.currentLevel > 0);
+          if (alivePlayers.length === 1) {
+            set({
+              players: newPlayers,
+              map: newMap,
+              phase: 'gameOver',
+              lastCombat: combat,
+              winner: alivePlayers[0],
+            });
+            return;
           }
-        } else {
-          // Monster defeated - clear it
-          newMap[y][x].monster = null;
         }
-
-        set({
-          players: newPlayers,
-          map: newMap,
-          phase: 'combat',
-          lastCombat: combat,
-        });
-        return;
+      } else {
+        // Monster defeated - clear it
+        newMap.set(key, { ...newTile, monster: null });
       }
+
+      set({
+        players: newPlayers,
+        map: newMap,
+        phase: 'combat',
+        lastCombat: combat,
+      });
+      return;
     }
+
+    // No combat - auto advance turn
+    const nextIndex = findNextAlivePlayer(newPlayers, currentPlayerIndex);
 
     set({
       players: newPlayers,
       map: newMap,
+      currentPlayerIndex: nextIndex,
     });
   },
 
   dismissCombat: () => {
     const { players, currentPlayerIndex } = get();
-    const currentPlayer = players[currentPlayerIndex];
 
-    // If current player is eliminated, skip to next alive player
-    let nextIndex = currentPlayerIndex;
-
-    if (currentPlayer.cup.currentLevel <= 0) {
-      // Find next alive player
-      for (let i = 1; i <= players.length; i++) {
-        const idx = (currentPlayerIndex + i) % players.length;
-        if (players[idx].cup.currentLevel > 0) {
-          nextIndex = idx;
-          break;
-        }
-      }
-    }
+    // Auto advance to next player after combat
+    const nextIndex = findNextAlivePlayer(players, currentPlayerIndex);
 
     set({
       phase: 'playing',
@@ -201,23 +177,27 @@ export const useGameStore = create<GameStore>((set, get) => ({
     });
   },
 
-  endTurn: () => {
-    const { players, currentPlayerIndex } = get();
-
-    // Find next alive player
-    let nextIndex = currentPlayerIndex;
-    for (let i = 1; i <= players.length; i++) {
-      const idx = (currentPlayerIndex + i) % players.length;
-      if (players[idx].cup.currentLevel > 0) {
-        nextIndex = idx;
-        break;
-      }
-    }
-
-    set({ currentPlayerIndex: nextIndex });
-  },
-
   resetGame: () => {
-    set(initialState);
+    set({
+      ...initialState,
+      map: new Map(), // Need fresh Map instance
+    });
   },
 }));
+
+// Helper to find next alive player
+function findNextAlivePlayer(players: Player[], currentIndex: number): number {
+  for (let i = 1; i <= players.length; i++) {
+    const idx = (currentIndex + i) % players.length;
+    if (players[idx].cup.currentLevel > 0) {
+      return idx;
+    }
+  }
+  return currentIndex;
+}
+
+// Export helper for components to check placeable positions
+export function getPlaceablePositions(map: HexMap, playerPos: HexCoord): HexCoord[] {
+  const neighbors = getHexNeighbors(playerPos.q, playerPos.r);
+  return neighbors.filter(n => !map.has(hexKey(n.q, n.r)));
+}

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -1,4 +1,4 @@
-// Core game types - ported from game.py
+// Core game types - hexagonal grid system
 
 export interface Cup {
   color: string;
@@ -6,11 +6,17 @@ export interface Cup {
   currentLevel: number;
 }
 
+// Axial coordinates for hex grid (q = column, r = row)
+export interface HexCoord {
+  q: number;
+  r: number;
+}
+
 export interface Player {
   id: string;
   name: string;
   cup: Cup;
-  position: { x: number; y: number };
+  position: HexCoord;
 }
 
 export interface Monster {
@@ -20,10 +26,9 @@ export interface Monster {
 }
 
 export interface Tile {
-  x: number;
-  y: number;
+  q: number;
+  r: number;
   monster: Monster | null;
-  revealed: boolean;
   isStart?: boolean;
 }
 
@@ -37,13 +42,27 @@ export interface CombatResult {
 
 export type GamePhase = 'setup' | 'playing' | 'combat' | 'gameOver';
 
+// Sparse hex map - only stores tiles that have been placed
+export type HexMap = Map<string, Tile>;
+
+// Helper to create map key from coords
+export const hexKey = (q: number, r: number): string => `${q},${r}`;
+
+// Get all 6 hex neighbors
+export const getHexNeighbors = (q: number, r: number): HexCoord[] => [
+  { q: q + 1, r: r },     // East
+  { q: q - 1, r: r },     // West
+  { q: q, r: r + 1 },     // Southeast
+  { q: q, r: r - 1 },     // Northwest
+  { q: q + 1, r: r - 1 }, // Northeast
+  { q: q - 1, r: r + 1 }, // Southwest
+];
+
 export interface GameState {
   players: Player[];
-  map: Tile[][];
+  map: HexMap;
   currentPlayerIndex: number;
   phase: GamePhase;
-  width: number;
-  height: number;
   lastCombat: CombatResult | null;
   winner: Player | null;
 }


### PR DESCRIPTION
- Replace square tiles with hexagonal grid (6 movement directions)
- Tiles now placed by exploring - hover to preview, click to place
- Turns automatically advance after placing a tile
- Health increased to 10 (displayed as cup icons)
- Remove "End Turn" button (now automatic)

https://claude.ai/code/session_01MNZxHRNrHsikk6kQJfbeFg