### PR TITLE
feat: turn enforcement, breathing animation, and GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useGameStore, getPlaceablePositions, getMoveablePositions } from '../game/store';
+import { useNetworkStore } from '../network/peer';
 import { Tile, Player, HexCoord } from '../game/types';
 
 const HEX_SIZE = 50; // Radius of hexagon
@@ -28,7 +29,7 @@ interface HexTileProps {
   tile: Tile;
   playersOnTile: Player[];
   pixelPos: { x: number; y: number };
-  isCurrentPlayerHere: boolean;
+  currentPlayerId: string | null;
   currentPlayerColor: string;
   isMoveable: boolean;
   isHovered: boolean;
@@ -40,7 +41,7 @@ function HexTile({
   tile,
   playersOnTile,
   pixelPos,
-  isCurrentPlayerHere,
+  currentPlayerId,
   currentPlayerColor,
   isMoveable,
   isHovered,
@@ -61,20 +62,6 @@ function HexTile({
       onClick={() => isMoveable && onClick()}
       style={{ cursor: isMoveable ? 'pointer' : 'default' }}
     >
-      {/* Breathing glow for current player's position */}
-      {isCurrentPlayerHere && (
-        <circle
-          cx={0}
-          cy={0}
-          r={HEX_SIZE * 0.9}
-          fill="none"
-          stroke="white"
-          strokeWidth={3}
-          opacity={0.6}
-          className="animate-breathe"
-        />
-      )}
-
       <path
         d={hexagonPath(HEX_SIZE - 2)}
         fill="#2a2a4a"
@@ -106,16 +93,30 @@ function HexTile({
         <g transform={`translate(0, ${HEX_SIZE * 0.5})`}>
           {playersOnTile.map((player, i) => {
             const offset = (i - (playersOnTile.length - 1) / 2) * 14;
+            const isCurrentPlayer = player.id === currentPlayerId;
             return (
-              <circle
-                key={player.id}
-                cx={offset}
-                cy={0}
-                r={6}
-                fill={player.cup.color}
-                stroke="white"
-                strokeWidth={2}
-              />
+              <g key={player.id}>
+                {/* Breathing glow ring for current player */}
+                {isCurrentPlayer && (
+                  <circle
+                    cx={offset}
+                    cy={0}
+                    r={10}
+                    fill="none"
+                    stroke="white"
+                    strokeWidth={2}
+                    className="animate-breathe"
+                  />
+                )}
+                <circle
+                  cx={offset}
+                  cy={0}
+                  r={6}
+                  fill={player.cup.color}
+                  stroke="white"
+                  strokeWidth={2}
+                />
+              </g>
             );
           })}
         </g>
@@ -168,21 +169,27 @@ function PlaceableHex({ coord, pixelPos, isHovered, playerColor, onHover, onClic
 
 export function Board() {
   const { map, players, currentPlayerIndex, phase, placeTile, moveTo } = useGameStore();
+  const { myPlayerIndex, isConnected } = useNetworkStore();
   const [hoveredCoord, setHoveredCoord] = useState<HexCoord | null>(null);
 
   const currentPlayer = players[currentPlayerIndex];
 
+  // In multiplayer, only allow moves when it's your turn
+  const isMyTurn = !isConnected || myPlayerIndex === currentPlayerIndex;
+
   // Get all placeable positions for current player (unexplored)
+  // Only show if it's your turn in multiplayer
   const placeablePositions = useMemo(() => {
-    if (phase !== 'playing' || !currentPlayer) return [];
+    if (phase !== 'playing' || !currentPlayer || !isMyTurn) return [];
     return getPlaceablePositions(map, currentPlayer.position);
-  }, [map, currentPlayer, phase]);
+  }, [map, currentPlayer, phase, isMyTurn]);
 
   // Get all moveable positions for current player (existing tiles to backtrack)
+  // Only show if it's your turn in multiplayer
   const moveablePositions = useMemo(() => {
-    if (phase !== 'playing' || !currentPlayer) return [];
+    if (phase !== 'playing' || !currentPlayer || !isMyTurn) return [];
     return getMoveablePositions(map, currentPlayer.position);
-  }, [map, currentPlayer, phase]);
+  }, [map, currentPlayer, phase, isMyTurn]);
 
   // Calculate bounds to center the view
   const bounds = useMemo(() => {
@@ -241,12 +248,17 @@ export function Board() {
       {/* CSS for breathing animation */}
       <style>{`
         @keyframes breathe {
-          0%, 100% { opacity: 0.3; transform: scale(1); }
-          50% { opacity: 0.7; transform: scale(1.05); }
+          0%, 100% {
+            opacity: 0.3;
+            stroke-width: 2;
+          }
+          50% {
+            opacity: 1;
+            stroke-width: 3;
+          }
         }
         .animate-breathe {
-          animation: breathe 2s ease-in-out infinite;
-          transform-origin: center;
+          animation: breathe 1.5s ease-in-out infinite;
         }
       `}</style>
 
@@ -276,7 +288,6 @@ export function Board() {
         {tiles.map(({ key, tile, pixelPos }) => {
           const isMoveable = isMoveablePosition(tile.q, tile.r);
           const isHovered = hoveredCoord?.q === tile.q && hoveredCoord?.r === tile.r;
-          const isCurrentPlayerHere = currentPlayer?.position.q === tile.q && currentPlayer?.position.r === tile.r;
 
           return (
             <HexTile
@@ -284,7 +295,7 @@ export function Board() {
               tile={tile}
               playersOnTile={getPlayersOnTile(tile.q, tile.r)}
               pixelPos={pixelPos}
-              isCurrentPlayerHere={isCurrentPlayerHere}
+              currentPlayerId={currentPlayer?.id ?? null}
               currentPlayerColor={currentPlayer?.cup.color ?? '#888'}
               isMoveable={isMoveable}
               isHovered={isHovered}
@@ -297,7 +308,9 @@ export function Board() {
 
       {phase === 'playing' && currentPlayer && (
         <p className="text-sm" style={{ color: currentPlayer.cup.color }}>
-          {currentPlayer.name}'s turn - click to explore or backtrack
+          {isMyTurn
+            ? `Your turn - click to explore or backtrack`
+            : `Waiting for ${currentPlayer.name}...`}
         </p>
       )}
     </div>

--- a/src/components/Lobby.tsx
+++ b/src/components/Lobby.tsx
@@ -13,6 +13,7 @@ export function Lobby({ onGameStart }: LobbyProps) {
 
   const {
     roomCode,
+    peerId,
     isHost,
     isConnected,
     players,
@@ -23,11 +24,15 @@ export function Lobby({ onGameStart }: LobbyProps) {
     broadcast,
     onMessage,
     clearError,
+    setMyPlayerIndex,
   } = useNetworkStore();
 
   // Listen for game start message (guests)
   onMessage((message) => {
-    if (message.type === 'game-start') {
+    if (message.type === 'game-start' && peerId) {
+      // Set which player index this client controls
+      const myIndex = message.peerToIndex[peerId] ?? -1;
+      setMyPlayerIndex(myIndex);
       onGameStart(message.playerNames);
     }
   });
@@ -62,12 +67,21 @@ export function Lobby({ onGameStart }: LobbyProps) {
   };
 
   const handleStartGame = () => {
-    if (!isHost || players.length < 2) return;
+    if (!isHost || players.length < 2 || !peerId) return;
 
     const playerNames = players.map(p => p.name);
 
-    // Broadcast game start to all players
-    broadcast({ type: 'game-start', playerNames });
+    // Map each peerId to their player index (lobby order = game order)
+    const peerToIndex: Record<string, number> = {};
+    players.forEach((p, i) => {
+      peerToIndex[p.peerId] = i;
+    });
+
+    // Broadcast game start to all players with index mapping
+    broadcast({ type: 'game-start', playerNames, peerToIndex });
+
+    // Set host's player index (always 0 since host is first)
+    setMyPlayerIndex(peerToIndex[peerId] ?? 0);
 
     // Start locally too
     onGameStart(playerNames);

--- a/src/network/peer.ts
+++ b/src/network/peer.ts
@@ -5,7 +5,7 @@ import { create } from 'zustand';
 export type NetworkMessage =
   | { type: 'player-join'; playerName: string; peerId: string }
   | { type: 'player-list'; players: NetworkPlayer[] }
-  | { type: 'game-start'; playerNames: string[] }
+  | { type: 'game-start'; playerNames: string[]; peerToIndex: Record<string, number> }
   | { type: 'game-action'; action: string; payload: unknown }
   | { type: 'game-state'; state: unknown }
   | { type: 'player-left'; peerId: string };
@@ -23,6 +23,7 @@ interface NetworkState {
   isHost: boolean;
   isConnected: boolean;
   players: NetworkPlayer[];
+  myPlayerIndex: number; // Which player index this client controls
   error: string | null;
 
   // Actions
@@ -33,6 +34,7 @@ interface NetworkState {
   disconnect: () => void;
   onMessage: (handler: (message: NetworkMessage, fromPeerId: string) => void) => void;
   clearError: () => void;
+  setMyPlayerIndex: (index: number) => void;
 }
 
 // Store connections (host keeps all, guest keeps one to host)
@@ -56,6 +58,7 @@ export const useNetworkStore = create<NetworkState>((set, get) => ({
   isHost: false,
   isConnected: false,
   players: [],
+  myPlayerIndex: -1,
   error: null,
 
   hostRoom: async (playerName: string): Promise<string> => {
@@ -230,6 +233,7 @@ export const useNetworkStore = create<NetworkState>((set, get) => ({
       isHost: false,
       isConnected: false,
       players: [],
+      myPlayerIndex: -1,
       error: null,
     });
   },
@@ -240,5 +244,9 @@ export const useNetworkStore = create<NetworkState>((set, get) => ({
 
   clearError: () => {
     set({ error: null });
+  },
+
+  setMyPlayerIndex: (index: number) => {
+    set({ myPlayerIndex: index });
   },
 }));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,4 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  // Base path for GitHub Pages deployment
+  // Change 'Barcadia' to your repo name if different
+  base: process.env.GITHUB_ACTIONS ? '/Barcadia/' : '/',
 })


### PR DESCRIPTION
Turn Management:
- Track which player index each client controls (myPlayerIndex)
- Only allow moves when it's your turn in multiplayer
- Show "Waiting for X..." when it's another player's turn
- Disable board interactions when not your turn

Breathing Animation:
- Moved from tile to player token (the colored circle)
- Now pulses around the active player's icon
- Smoother animation with opacity and stroke-width

GitHub Pages Deployment:
- Added GitHub Actions workflow for automatic deploys
- Configured vite base path for GitHub Pages
- Push to main -> site deploys to https://<username>.github.io/Barcadia/

https://claude.ai/code/session_01MNZxHRNrHsikk6kQJfbeFg