### PR TITLE
fix: consolidate message handling so turns sync properly

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useGameStore, setNetworkBroadcast } from './game/store';
 import { useNetworkStore } from './network/peer';
 import { Board } from './components/Board';
@@ -86,7 +86,17 @@ function GameScreen() {
 
 export default function App() {
   const { phase, startGame, applyNetworkState } = useGameStore();
-  const { isHost, isConnected, broadcast, onMessage } = useNetworkStore();
+  const { peerId, isHost, isConnected, broadcast, onMessage, setMyPlayerIndex } = useNetworkStore();
+
+  // Handle game start (called by Lobby for host, or via network for guests)
+  const handleGameStart = useCallback((playerNames: string[], peerToIndex?: Record<string, number>) => {
+    // Set player index if provided (for both host and guest)
+    if (peerToIndex && peerId) {
+      const myIndex = peerToIndex[peerId] ?? -1;
+      setMyPlayerIndex(myIndex);
+    }
+    startGame(playerNames);
+  }, [peerId, setMyPlayerIndex, startGame]);
 
   // Set up network broadcast when connected as host
   useEffect(() => {
@@ -103,19 +113,19 @@ export default function App() {
     };
   }, [isConnected, isHost, broadcast]);
 
-  // Listen for network messages (guests receive state updates)
+  // Listen for ALL network messages
   useEffect(() => {
     onMessage((message) => {
+      // Handle game start (guests receive this from host)
+      if (message.type === 'game-start') {
+        handleGameStart(message.playerNames, message.peerToIndex);
+      }
+      // Handle game state updates (guests receive ongoing state)
       if (message.type === 'game-state' && !isHost) {
         applyNetworkState(message.state as Parameters<typeof applyNetworkState>[0]);
       }
     });
-  }, [onMessage, isHost, applyNetworkState]);
-
-  // Handle game start from lobby
-  const handleGameStart = (playerNames: string[]) => {
-    startGame(playerNames);
-  };
+  }, [onMessage, isHost, applyNetworkState, handleGameStart]);
 
   // Show lobby if in setup phase
   if (phase === 'setup') {

--- a/src/components/Lobby.tsx
+++ b/src/components/Lobby.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useNetworkStore } from '../network/peer';
 
 interface LobbyProps {
-  onGameStart: (playerNames: string[]) => void;
+  onGameStart: (playerNames: string[], peerToIndex?: Record<string, number>) => void;
 }
 
 export function Lobby({ onGameStart }: LobbyProps) {
@@ -22,20 +22,8 @@ export function Lobby({ onGameStart }: LobbyProps) {
     joinRoom,
     disconnect,
     broadcast,
-    onMessage,
     clearError,
-    setMyPlayerIndex,
   } = useNetworkStore();
-
-  // Listen for game start message (guests)
-  onMessage((message) => {
-    if (message.type === 'game-start' && peerId) {
-      // Set which player index this client controls
-      const myIndex = message.peerToIndex[peerId] ?? -1;
-      setMyPlayerIndex(myIndex);
-      onGameStart(message.playerNames);
-    }
-  });
 
   const handleHost = async () => {
     if (!playerName.trim()) return;
@@ -80,11 +68,8 @@ export function Lobby({ onGameStart }: LobbyProps) {
     // Broadcast game start to all players with index mapping
     broadcast({ type: 'game-start', playerNames, peerToIndex });
 
-    // Set host's player index (always 0 since host is first)
-    setMyPlayerIndex(peerToIndex[peerId] ?? 0);
-
-    // Start locally too
-    onGameStart(playerNames);
+    // Start locally with the peerToIndex mapping
+    onGameStart(playerNames, peerToIndex);
   };
 
   const handleBack = () => {


### PR DESCRIPTION
The bug was that onMessage was being called in both Lobby and App, but there's only ONE global message handler - the second call overwrites the first. So guests never received 'game-start' messages and their myPlayerIndex stayed at -1, locking them out.

Fixed by:
- Moving ALL message handling to App.tsx
- App handles both 'game-start' and 'game-state' messages
- Lobby no longer calls onMessage, just passes peerToIndex to onGameStart
- Now both host and guests correctly set their myPlayerIndex

https://claude.ai/code/session_01MNZxHRNrHsikk6kQJfbeFg