### PR TITLE
fix: guests send actions to host instead of executing locally

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,13 +18,22 @@ function GameScreen() {
     resetGame,
   } = useGameStore();
 
-  const { isConnected, disconnect } = useNetworkStore();
+  const { isConnected, isHost, sendToHost, disconnect } = useNetworkStore();
 
   const currentPlayer = players[currentPlayerIndex];
 
   const handleLeaveGame = () => {
     disconnect();
     resetGame();
+  };
+
+  // Network-aware dismiss - guests send to host
+  const handleDismissCombat = () => {
+    if (isConnected && !isHost) {
+      sendToHost({ type: 'game-action', action: 'dismissCombat', payload: {} });
+    } else {
+      dismissCombat();
+    }
   };
 
   return (
@@ -72,7 +81,7 @@ function GameScreen() {
         <CombatModal
           combat={lastCombat}
           playerName={currentPlayer.name}
-          onDismiss={dismissCombat}
+          onDismiss={handleDismissCombat}
         />
       )}
 
@@ -85,7 +94,7 @@ function GameScreen() {
 }
 
 export default function App() {
-  const { phase, startGame, applyNetworkState } = useGameStore();
+  const { phase, startGame, applyNetworkState, placeTile, moveTo, dismissCombat } = useGameStore();
   const { peerId, isHost, isConnected, broadcast, onMessage, setMyPlayerIndex } = useNetworkStore();
 
   // Handle game start (called by Lobby for host, or via network for guests)
@@ -124,8 +133,21 @@ export default function App() {
       if (message.type === 'game-state' && !isHost) {
         applyNetworkState(message.state as Parameters<typeof applyNetworkState>[0]);
       }
+      // Handle game actions from guests (host executes them)
+      if (message.type === 'game-action' && isHost) {
+        const { action, payload } = message;
+        if (action === 'placeTile') {
+          const { q, r } = payload as { q: number; r: number };
+          placeTile(q, r);
+        } else if (action === 'moveTo') {
+          const { q, r } = payload as { q: number; r: number };
+          moveTo(q, r);
+        } else if (action === 'dismissCombat') {
+          dismissCombat();
+        }
+      }
     });
-  }, [onMessage, isHost, applyNetworkState, handleGameStart]);
+  }, [onMessage, isHost, applyNetworkState, handleGameStart, placeTile, moveTo, dismissCombat]);
 
   // Show lobby if in setup phase
   if (phase === 'setup') {

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -169,13 +169,34 @@ function PlaceableHex({ coord, pixelPos, isHovered, playerColor, onHover, onClic
 
 export function Board() {
   const { map, players, currentPlayerIndex, phase, placeTile, moveTo } = useGameStore();
-  const { myPlayerIndex, isConnected } = useNetworkStore();
+  const { myPlayerIndex, isConnected, isHost, sendToHost } = useNetworkStore();
   const [hoveredCoord, setHoveredCoord] = useState<HexCoord | null>(null);
 
   const currentPlayer = players[currentPlayerIndex];
 
   // In multiplayer, only allow moves when it's your turn
   const isMyTurn = !isConnected || myPlayerIndex === currentPlayerIndex;
+
+  // Wrapper to handle actions - host executes locally, guests send to host
+  const handlePlaceTile = (q: number, r: number) => {
+    if (isConnected && !isHost) {
+      // Guest: send action to host
+      sendToHost({ type: 'game-action', action: 'placeTile', payload: { q, r } });
+    } else {
+      // Host or local: execute directly
+      placeTile(q, r);
+    }
+  };
+
+  const handleMoveTo = (q: number, r: number) => {
+    if (isConnected && !isHost) {
+      // Guest: send action to host
+      sendToHost({ type: 'game-action', action: 'moveTo', payload: { q, r } });
+    } else {
+      // Host or local: execute directly
+      moveTo(q, r);
+    }
+  };
 
   // Get all placeable positions for current player (unexplored)
   // Only show if it's your turn in multiplayer
@@ -279,7 +300,7 @@ export function Board() {
               isHovered={isHovered}
               playerColor={currentPlayer?.cup.color ?? '#888'}
               onHover={setHoveredCoord}
-              onClick={() => placeTile(coord.q, coord.r)}
+              onClick={() => handlePlaceTile(coord.q, coord.r)}
             />
           );
         })}
@@ -300,7 +321,7 @@ export function Board() {
               isMoveable={isMoveable}
               isHovered={isHovered}
               onHover={setHoveredCoord}
-              onClick={() => moveTo(tile.q, tile.r)}
+              onClick={() => handleMoveTo(tile.q, tile.r)}
             />
           );
         })}


### PR DESCRIPTION
The issue was that when a guest took a turn, they executed the action locally but it never got broadcast - only the host broadcasts state. So after guest's turn, the guest had updated state but host didn't.

Fixed by implementing proper client-server flow:
- Guests send game-action messages to host (placeTile, moveTo, dismissCombat)
- Host receives actions and executes them
- Host's execution triggers broadcastState() to all players
- Everyone stays in sync

Now turn order properly cycles through all players.

https://claude.ai/code/session_01MNZxHRNrHsikk6kQJfbeFg