### PR TITLE
feat: combat popup - anyone can dismiss locally, only active player a…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { useGameStore, setNetworkBroadcast } from './game/store';
 import { useNetworkStore } from './network/peer';
 import { Board } from './components/Board';
@@ -18,23 +18,43 @@ function GameScreen() {
     resetGame,
   } = useGameStore();
 
-  const { isConnected, isHost, sendToHost, disconnect } = useNetworkStore();
+  const { isConnected, isHost, sendToHost, disconnect, myPlayerIndex } = useNetworkStore();
+
+  // Local state: has this user dismissed the combat modal on their screen?
+  const [locallyDismissed, setLocallyDismissed] = useState(false);
+
+  // Reset local dismiss when new combat occurs
+  useEffect(() => {
+    if (phase === 'combat' && lastCombat) {
+      setLocallyDismissed(false);
+    }
+  }, [phase, lastCombat]);
 
   const currentPlayer = players[currentPlayerIndex];
+  const isMyTurn = !isConnected || myPlayerIndex === currentPlayerIndex;
 
   const handleLeaveGame = () => {
     disconnect();
     resetGame();
   };
 
-  // Network-aware dismiss - guests send to host
+  // Handle combat dismiss
   const handleDismissCombat = () => {
-    if (isConnected && !isHost) {
-      sendToHost({ type: 'game-action', action: 'dismissCombat', payload: {} });
+    if (isMyTurn) {
+      // It's my combat - actually advance the turn
+      if (isConnected && !isHost) {
+        sendToHost({ type: 'game-action', action: 'dismissCombat', payload: {} });
+      } else {
+        dismissCombat();
+      }
     } else {
-      dismissCombat();
+      // Not my combat - just hide it locally
+      setLocallyDismissed(true);
     }
   };
+
+  // Show combat modal if in combat phase AND not locally dismissed
+  const showCombatModal = phase === 'combat' && lastCombat && !locallyDismissed;
 
   return (
     <div className="min-h-screen p-4">
@@ -77,11 +97,12 @@ function GameScreen() {
       </div>
 
       {/* Combat modal */}
-      {phase === 'combat' && lastCombat && (
+      {showCombatModal && (
         <CombatModal
           combat={lastCombat}
           playerName={currentPlayer.name}
           onDismiss={handleDismissCombat}
+          isMyTurn={isMyTurn}
         />
       )}
 

--- a/src/components/CombatModal.tsx
+++ b/src/components/CombatModal.tsx
@@ -4,9 +4,10 @@ interface CombatModalProps {
   combat: CombatResult;
   playerName: string;
   onDismiss: () => void;
+  isMyTurn?: boolean;
 }
 
-export function CombatModal({ combat, playerName, onDismiss }: CombatModalProps) {
+export function CombatModal({ combat, playerName, onDismiss, isMyTurn = true }: CombatModalProps) {
   const { roll, needed, won, monster, damage } = combat;
 
   return (
@@ -47,8 +48,13 @@ export function CombatModal({ combat, playerName, onDismiss }: CombatModalProps)
           className="w-full py-3 bg-dungeon-accent hover:bg-dungeon-accent/80
                      text-white font-bold rounded-lg transition-colors"
         >
-          Continue
+          {isMyTurn ? 'Continue' : 'Dismiss'}
         </button>
+        {!isMyTurn && (
+          <p className="text-gray-500 text-xs mt-2">
+            Waiting for {playerName} to continue...
+          </p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
…dvances turn

- Combat modal shows for all players (unchanged)
- Non-active players see "Dismiss" button - hides modal locally
- Active player sees "Continue" button - advances the turn
- Shows "Waiting for X to continue..." for non-active players
- Local dismiss state resets when new combat occurs

This lets everyone read at their own pace without someone else clicking Continue and advancing the turn prematurely.

https://claude.ai/code/session_01MNZxHRNrHsikk6kQJfbeFg